### PR TITLE
#52 Configuração das rotas no navbar 

### DIFF
--- a/front/src/app/app-routing.module.ts
+++ b/front/src/app/app-routing.module.ts
@@ -8,7 +8,9 @@ import { IssuesComponent } from './pages/issues/issues.component';
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: 'dashboard', component: DashboardComponent },
-  { path: 'issues', component: IssuesComponent }
+  { path: 'issues', component: IssuesComponent },
+  { path: 'burndown', component: IssuesComponent },
+  { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
 
 ];
 

--- a/front/src/app/components/nav-bar/nav-bar.component.html
+++ b/front/src/app/components/nav-bar/nav-bar.component.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow nav-custom">
-    <div class="collapse navbar-collapse">
+    <div routerLink="/dashboard" class="collapse navbar-collapse">
         <a class="navbar-brand" href="#">Gitlab + |</a>
         <ul class="navbar-nav mr-auto navbar-menu">
             <li class="nav-item active">

--- a/front/src/app/components/nav-bar/nav-bar.component.html
+++ b/front/src/app/components/nav-bar/nav-bar.component.html
@@ -3,16 +3,16 @@
         <a class="navbar-brand" href="#">Gitlab + |</a>
         <ul class="navbar-nav mr-auto navbar-menu">
             <li class="nav-item active">
-                <a class="nav-link" href="#">Home</a>
+                <a routerLink="/login" class="nav-link" href="#">Home</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="#">Dashboard</a>
+                <a routerLink="/dashboard" class="nav-link" href="#">Dashboard</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="#">Issues</a>
+                <a routerLink="/issues" class="nav-link" href="#">Issues</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="#">Burndown</a>
+                <a routerLink="/burndown" class="nav-link" href="#">Burndown</a>
             </li>
         </ul>
         <ul class="navbar-nav ml-auto">


### PR DESCRIPTION
Configuração de rotas no navbar foram feitas seguindo os seguintes princípios:

- A página inicial do gitlab+ é a do dashboard.

- Toda vez que for feito uma requisição para o 'http://localhost:4200/', a página será redirecionada para o 'http://localhost:4200/dashboard'.

- O logotipo do gitlab+ no navbar, é um link para a página inicial.

- Quem desenvolver o Burndown, alterar a property component do app-routing-modules.ts onde possui o path 'burndown' para o component criado pelo desenvolvedor do burndown.